### PR TITLE
fixed unnecessary cutting

### DIFF
--- a/lib/prepare-data.sh
+++ b/lib/prepare-data.sh
@@ -242,13 +242,13 @@ else
 		for((i=0;i<$stem_count;++i)); do
 		    stem_string="$stem_string ${stems_chrono[$i]}"		    
 		done
-		
-		if [ $debug -ge 1 ]; then
-		    echo; echo "Executing assemble_tops with parameters:"
-		    echo "$azimuth_min $azimuth_max $stem_string $work_PATH/preprocessing/$stem"
-		fi
-		assemble_tops $azimuth_min $azimuth_max $stem_string $work_PATH/preprocessing/$stem
-			
+		if [ $cut_to_aoi -eq 1 ]; then
+		    if [ $debug -ge 1 ]; then
+		        echo; echo "Executing assemble_tops with parameters:"
+		        echo "$azimuth_min $azimuth_max $stem_string $work_PATH/preprocessing/$stem"
+		    fi
+		    assemble_tops $azimuth_min $azimuth_max $stem_string $work_PATH/preprocessing/$stem
+		fi	
 		cd $work_PATH/preprocessing/
 
 		# Generate new PRM files for assembled tops


### PR DESCRIPTION
it cutted although the aoi-flag set to 0 in the xyz.config-file. just putting a checkup with on the parameter before assemble_tops might solve the Problem, but one has to think about to set it way before to speed up calculation and get rid of excessive files for this case